### PR TITLE
fix: only show allowed actions

### DIFF
--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -138,7 +138,10 @@
           <span>{{ $t('Unshelve') }}</span>
         </v-tooltip>
 
-        <v-tooltip bottom>
+        <v-tooltip
+          v-if="isAlertAlarmModel()"
+          bottom
+        >
           <v-btn
             slot="activator"
             :disabled="isClosed(item.status)"
@@ -155,7 +158,10 @@
           <span>{{ $t('Close') }}</span>
         </v-tooltip>
 
-        <v-tooltip bottom>
+        <v-tooltip
+          v-if="haveDeleteScope()"
+          bottom
+        >
           <v-btn
             slot="activator"
             icon
@@ -961,6 +967,14 @@ export default {
     },
     getNotes() {
       this.$store.dispatch('alerts/getNotes', this.id)
+    },
+    haveDeleteScope(){
+      const scopes = this.$store.getters['auth/scopes']
+      if (this.$config.delete_alert_scope_enforced) return scopes.includes('admin') || scopes.includes('admin:alerts') || scopes.includes('delete:alerts')
+      else return scopes.includes('admin') || scopes.includes('admin:alerts') || scopes.includes('write') || scopes.includes('write:alerts') || scopes.includes('delete:alerts')
+    },
+    isAlertAlarmModel(){
+      return !this.$config.alarm_model.name.includes('ISA 18')
     },
     isOpen(status) {
       return status == 'open' || status == 'NORM' || status == 'UNACK' || status == 'RTNUN'

--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -390,7 +390,7 @@
               </v-btn>
 
               <v-btn
-                v-if="!isClosed(props.item.status)"
+                v-if="!isClosed(props.item.status) && isAlertAlarmModel()"
                 flat
                 icon
                 small
@@ -404,6 +404,7 @@
                 </v-icon>
               </v-btn>
               <v-btn
+                v-if="haveDeleteScope()"
                 flat
                 icon
                 small
@@ -660,6 +661,14 @@ export default {
     },
     isClosed(status) {
       return status == 'closed'
+    },
+    haveDeleteScope(){
+      const scopes = this.$store.getters['auth/scopes']
+      if (this.$config.delete_alert_scope_enforced) return scopes.includes('admin') || scopes.includes('admin:alerts') || scopes.includes('delete:alerts')
+      else return scopes.includes('admin') || scopes.includes('admin:alerts') || scopes.includes('write') || scopes.includes('write:alerts') || scopes.includes('delete:alerts')
+    },
+    isAlertAlarmModel(){
+      return !this.$config.alarm_model.name.includes('ISA 18')
     },
     takeAction: debounce(function(id, action) {
       this.$store


### PR DESCRIPTION
**Description**
Removes/hides action buttons that are not allowed to be used

**Changes**
Include a brief summary of changes...
- removes/hides the delete button/action without the correct permission
- removes/hides the close button when the alarm model is not set to the Alerta model

