### PR TITLE
fix: add "unack" to open status check

### DIFF
--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -977,7 +977,7 @@ export default {
       return !this.$config.alarm_model.name.includes('ISA 18')
     },
     isOpen(status) {
-      return status == 'open' || status == 'NORM' || status == 'UNACK' || status == 'RTNUN'
+      return status == 'open' || status == 'NORM' || status == 'UNACK' || status == 'RTNUN' || status == 'unack'
     },
     isWatched(tags) {
       const tag = `watch:${this.username}`


### PR DESCRIPTION
**Description**
Add "unack" to the open status check in the alert detail view to support the basic status style that the ALERTA_ISA_18_2 alarm model is using.

Fixes #22 

**Changes**
- Add "unack" to the open status check in the alert detail view
