### PR TITLE
fix: send utc time to backend when adding new on call

### DIFF
--- a/src/components/OnCallList.vue
+++ b/src/components/OnCallList.vue
@@ -749,7 +749,9 @@ export default {
         this.$store.dispatch(
           'onCalls/createOnCall',
           Object.assign(this.editedItem, {
-            id: null
+            id: null,
+            startTime: this.fix_time(this.editedItem.startTime, true),
+            endTime: this.fix_time(this.editedItem.endTime, true),
           })
         )
       }


### PR DESCRIPTION
**Description**
Sends times in UTC to backend when making a new on-call rule

**Changes**
- fix times when saving new on call

