### PR TITLE
feat: add notification send for sending custom sms and mail.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -667,6 +667,13 @@ export default {
         },
         {
           icon: 'notifications',
+          text: i18n.t('Notification Send'),
+          path: '/notificationsend',
+          perms: 'read:notification_channels',
+          show: true
+        },
+        {
+          icon: 'notifications',
           text: i18n.t('Notification Channels'),
           path: '/notificationchannels',
           perms: 'read:notification_channels',

--- a/src/components/NotificationSendList.vue
+++ b/src/components/NotificationSendList.vue
@@ -1,0 +1,203 @@
+<template>
+  <div>
+    <v-card>
+      <v-card-title class="title">
+        {{ $t('Notification Send') }}
+        <v-spacer />
+        <v-select
+          v-model="emailChannel"
+          :items="emailNotificationChannels"
+          :label="$t('EmailChannel')"
+          item-text="id"
+          item-value="id"
+        />
+        <v-spacer />
+        <v-select
+          v-model="smsChannel"
+          :items="smsNotificationChannels"
+          :label="$t('SMSChannel')"
+          item-text="id"
+          item-value="id"
+        />
+        <v-spacer />
+        <v-text-field
+          v-model="text"
+          :label="$t('Text')"
+        />
+        <v-spacer />
+        <v-btn @click="send">
+          {{ $t('Send') }}
+        </v-btn>
+      </v-card-title>
+
+      <v-data-table
+        v-model="notifications"
+        :headers="computedHeaders"
+        :items="sends"
+        :pagination.sync="pagination"
+        class="px-2"
+        :loading="isLoading"
+        must-sort
+        sort-icon="arrow_drop_down"
+      >
+        <template
+          slot="items"
+          slot-scope="props"
+        >
+          <td>{{ props.item.name }}</td>
+          <td>{{ props.item.type }}</td>
+          <td>
+            <v-checkbox 
+              v-model="props.item.mail"
+              @change="updateNotifcationSend(props.item)"
+            />
+          </td>
+          <td>
+            <v-checkbox 
+              v-model="props.item.sms"
+              @change="updateNotifcationSend(props.item)"
+            />
+          </td>
+        </template>
+      </v-data-table>
+    </v-card>
+  </div>
+</template>
+
+<script>
+import i18n from '@/plugins/i18n'
+
+export default {
+  data: vm => ({
+    pagination: {
+      sortBy: 'name',
+      rowsPerPage: 20,
+      
+    },
+    notifications: [],
+    types: [
+      { text: 'sendgrid (mail)', value: 'sendgrid', email: true },
+      { text: 'smtp (mail)', value: 'smtp', email: true },
+      { text: 'twilio (sms)', value: 'twilio_sms', email: false },
+      { text: 'twilio (call + sms)', value: 'twilio_call', email: false },
+      { text: 'link moblity xml (sms)', value: 'link_mobility_xml', email: false },
+      { text: 'my link', value: 'my_link', email: false }
+    ],
+    emailChannel: '',
+    smsChannel: '',
+    text: 'Hello, this is a text from notification send',
+    headers: [
+      { text: i18n.t('Name'), value: 'name' },
+      { text: i18n.t('Type'), value: 'type' },
+      { text: i18n.t('Mail'), value: 'mail' },
+      { text: i18n.t('SMS'), value: 'sms' }
+    ],
+  }),
+  computed: {
+    sends() {
+      return this.$store.state.notificationSends.notifications
+        .map(b => Object.assign({}, b))
+    },
+    emailNotificationChannels() {
+      return this.$store.state.notificationChannels.notification_channels
+        .filter (b => {
+          for (const type of this.types) {
+            if (type.value != b.type) continue
+            return type.email
+          }
+        })
+    },
+    smsNotificationChannels() {
+      return this.$store.state.notificationChannels.notification_channels
+        .filter (b => {
+          for (const type of this.types) {
+            if (type.value != b.type) continue
+            return !type.email
+          }
+        })
+    },
+    computedHeaders() {
+      return this.headers
+    },
+    isLoading() {
+      return this.$store.state.notificationChannels.isLoading || this.$store.state.users.isLoading || this.$store.state.notificationGroups.isLoading
+    },
+    formTitle() {
+      return !this.editedId
+        ? i18n.t('NewNotificationChannel')
+        : i18n.t('EditNotificationChannel')
+    },
+    refresh() {
+      return this.$store.state.refresh
+    }
+  },
+  watch: {
+    refresh(val) {
+      if (!val) return
+      this.getNotificationChannels()
+      this.getUsersAndGroups()
+    },
+    pagination: {
+      handler() {
+        this.getNotificationChannels()
+      },
+      deep: true
+    }
+  },
+  created() {
+    this.getNotificationChannels()
+    this.getUsersAndGroups()
+  },
+  methods: {
+    send() {
+      if (this.emailChannel){
+        const emailNotifications = this.sends.filter(b => b.mail)
+        this.$store.dispatch(
+          'notificationSends/sendNotification',
+          [
+            this.emailChannel,
+            {
+              receivers: [],
+              text: this.text,
+              notifications: emailNotifications
+            }
+          ]
+        )
+      }
+      if (this.smsChannel) {
+        const smsNotifications = this.sends.filter(b => b.sms)
+        this.$store.dispatch(
+          'notificationSends/sendNotification',
+          [
+            this.smsChannel,
+            {
+              receivers: [],
+              text: this.text,
+              notifications: smsNotifications
+            }
+          ]
+        )
+      }
+    },
+    updateNotifcationSend(item) {
+      this.$store.dispatch(
+        'notificationSends/updateNotificationSend',
+        [
+          item.id,
+          {
+            mail: item.mail,
+            sms: item.sms
+          }
+        ])
+    },
+    getNotificationChannels() {
+      this.$store.dispatch('notificationChannels/getNotificationChannels')
+    },
+    getUsersAndGroups() {
+      this.$store.dispatch('notificationSends/getNotificationSends')
+    },
+  }
+}
+</script>
+
+<style></style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -86,6 +86,12 @@ export function createRouter(basePath): VueRouter {
         meta: {title: 'NotificationDelays', requiresAuth: true}
       },
       {
+        path: '/notificationsend',
+        name: 'notificationsend',
+        component: () => import(/* webpackChunkName: 'user' */ './views/NotificationSend.vue'),
+        meta: {title: 'NotificationSend', requiresAuth: true}
+      },
+      {
         path: '/notificationrules',
         name: 'notificationrules',
         props: route => ({

--- a/src/services/api/notificationSend.service.ts
+++ b/src/services/api/notificationSend.service.ts
@@ -1,0 +1,16 @@
+import api from './index'
+
+export default {
+  getNotificationSends(query: object) {
+    let config = {
+      params: query
+    }
+    return api.get('/notificationsends', config)
+  },
+  updateNotificationSend(id: string, data: object) {
+    return api.put(`/notificationsends/${id}`, data)
+  },
+  sendNotification(id: string, data: object) {
+    return api.post(`/notificationsends/${id}/send`, data)
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,6 +4,7 @@ import config from './modules/config.store'
 import alerts from './modules/alerts.store'
 import heartbeats from './modules/heartbeats.store'
 import blackouts from './modules/blackouts.store'
+import notificationSends from './modules/notificationSends.store'
 import notificationRules from './modules/notificationRule.store'
 import notificationHistory from './modules/notificationHistory.store'
 import notificationDelays from './modules/notificationDelay.store'
@@ -51,6 +52,7 @@ export function createStore(): Store<any> {
       alerts,
       heartbeats,
       blackouts,
+      notificationSends,
       notificationRules,
       notificationDelays,
       notificationHistory,

--- a/src/store/modules/notificationSends.store.ts
+++ b/src/store/modules/notificationSends.store.ts
@@ -1,0 +1,77 @@
+import NotificationSendApi from '@/services/api/notificationSend.service'
+
+const namespaced = true
+
+const state = {
+  isLoading: false,
+
+  notifications: [],
+  pagination: {
+    page: 1,
+    rowsPerPage: 20,
+    sortBy: 'id',
+    descending: true,
+    rowsPerPageItems: [10, 20, 50, 100, 200]
+  }
+}
+
+const mutations = {
+  SET_LOADING(state) {
+    state.isLoading = true
+  },
+  SET_NOTIFICATION_SEND(state, [notificationSends, total, pageSize]) {
+    state.isLoading = false
+    state.notifications = notificationSends
+    state.pagination.totalItems = total
+    state.pagination.rowsPerPage = pageSize
+  },
+  RESET_LOADING(state) {
+    state.isLoading = false
+  },
+  SET_PAGINATION(state, pagination) {
+    state.pagination = Object.assign({}, state.pagination, pagination)
+  }
+}
+
+const actions = {
+  getNotificationSends({commit, state}) {
+    commit('SET_LOADING')
+
+    let params = new URLSearchParams(state.query)
+
+    // add server-side paging
+    params.append('page', state.pagination.page)
+    params.append('page-size', state.pagination.rowsPerPage)
+
+    // add server-side sort
+    params.append('sort-by', (state.pagination.descending ? '-' : '') + state.pagination.sortBy)
+
+    return NotificationSendApi.getNotificationSends(params)
+      .then(({notificationSends: notificationSends, total, pageSize}) =>
+        commit('SET_NOTIFICATION_SEND', [notificationSends, total, pageSize])
+      )
+      .catch(() => commit('RESET_LOADING'))
+  },
+  updateNotificationSend({dispatch, commit}, [notificationChannelId, update]) {
+    return NotificationSendApi.updateNotificationSend(notificationChannelId, update).then(response => {
+      dispatch('getNotificationSends')
+    })
+  },
+  sendNotification({dispatch, commit}, [notificationChannelId, data]) {
+    return NotificationSendApi.sendNotification(notificationChannelId, data)
+  }
+}
+
+const getters = {
+  pagination: state => {
+    return state.pagination
+  }
+}
+
+export default {
+  namespaced,
+  state,
+  mutations,
+  actions,
+  getters
+}

--- a/src/views/NotificationSend.vue
+++ b/src/views/NotificationSend.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="notificationsend">
+    <notification-send-list />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import NotificationSendList from '@/components/NotificationSendList.vue'
+
+@Component({
+  components: {
+    NotificationSendList
+  }
+})
+export default class NotificationSend extends Vue {}
+</script>


### PR DESCRIPTION
**Description**
Add a view for sending custom sms and mail to users and notification groups

**Changes**
- add notification send view

**Screenshots**
![image](https://github.com/user-attachments/assets/61f34ecf-377d-457f-9636-8956079119fd)