### PR TITLE
fix: environment tabs in alert history

### DIFF
--- a/src/services/api/alert.service.ts
+++ b/src/services/api/alert.service.ts
@@ -54,6 +54,9 @@ export default {
     }
     return api.get('/alerts/history', config)
   },
+  getAlertHistoryCount() {
+    return api.get('/alerts/history/count')
+  },
   getCounts(query: object) {
     let config = {
       params: query

--- a/src/store/modules/alerts.store.ts
+++ b/src/store/modules/alerts.store.ts
@@ -13,6 +13,7 @@ const state = {
   history: [],
   selected: [], // used by multi-select checkboxes
   environments: [],
+  historyEnvironments: [],
   services: [],
   groups: [],
   tags: [],
@@ -75,6 +76,9 @@ const mutations = {
   SET_HISTORY(state, [history, total]): any {
     state.history = history
     state.historyPagination.totalItems = total
+  },
+  SET_HISTORY_ENVIRONMENTS(state, [environments, total]) {
+    state.historyEnvironments = {ALL: total, ...environments}
   },
   RESET_LOADING(state): any {
     state.isLoading = false
@@ -190,15 +194,20 @@ const actions = {
   getAlertHistory({commit, state}) {
     let params = new URLSearchParams(state.query)
 
-    state.historyFilter.environment && params.append('environment', state.filter.environment)
+    state.historyFilter.environment && params.append('environment', state.historyFilter.environment)
 
     params.append('page', state.historyPagination.page)
     params.append('page-size', state.historyPagination.rowsPerPage)
 
     return AlertsApi.getAlertHistory(params).then(({history, total}) => commit('SET_HISTORY', [history, total]))
   },
+  getAlertHistoryCount({commit, state}) {
+    return AlertsApi.getAlertHistoryCount().then(({environments, total}) =>
+      commit('SET_HISTORY_ENVIRONMENTS', [environments, total])
+    )
+  },
   setHistoryFilter({commit}, filter) {
-    commit('SET_FILTER', filter)
+    commit('SET_HISTORY_FILTER', filter)
   },
   updateQuery({commit}, query) {
     commit('SET_SEARCH_QUERY', query)
@@ -364,6 +373,9 @@ const getters = {
       },
       {ALL: 0}
     )
+  },
+  historyCounts: state => {
+    return state.historyEnvironments
   },
   services: state => {
     return state.services.map(s => s.service).sort()

--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -33,7 +33,7 @@
             <keep-alive max="1">
               <history-list
                 v-if="env == filter.environment || env == 'ALL'"
-                :history="historyByEnvironment"
+                :history="history"
               />
             </keep-alive>
           </v-tab-item>
@@ -46,10 +46,7 @@
 <script>
 import HistoryList from '@/components/HistoryList.vue'
 
-import moment from 'moment'
-import { ExportToCsv } from 'export-to-csv'
 import utils from '@/common/utils'
-import i18n from '@/plugins/i18n'
 
 export default {
   components: {
@@ -85,16 +82,7 @@ export default {
       return this.$store.state.alerts.historyFilter
     },
     history() {
-      if (this.filter) {
-        return this.$store.getters['alerts/history']
-          .filter(alert =>
-            this.filter.text
-              ? Object.keys(alert).some(k => alert[k] && alert[k].toString().toLowerCase().includes(this.filter.text.toLowerCase()))
-              : true
-          )
-      } else {
-        return this.$store.getters['alerts/history']
-      }
+      return this.$store.getters['alerts/history']
     },
     showAllowedEnvs() {
       return this.$store.getters.getPreference('showAllowedEnvs')
@@ -103,14 +91,7 @@ export default {
       return ['ALL'].concat(this.$store.getters['alerts/environments'](this.showAllowedEnvs))
     },
     environmentCounts() {
-      return this.$store.getters['alerts/counts']
-    },
-    historyByEnvironment() {
-      return this.history.filter(history =>
-        this.filter.environment
-          ? history.environment === this.filter.environment
-          : true
-      )
+      return this.$store.getters['alerts/historyCounts']
     },
     refreshInterval() {
       return (
@@ -134,6 +115,7 @@ export default {
   watch: {
     currentTab(val) {
       this.setPage(1)
+      this.getHistory()
     },
     pagination: {
       handler(newVal, oldVal) {
@@ -189,6 +171,7 @@ export default {
       this.$store.dispatch('alerts/setPanel', panel.asi == '1')
     },
     getHistory() {
+      this.$store.dispatch('alerts/getAlertHistoryCount')
       return this.$store.dispatch('alerts/getAlertHistory')
     },
     setSearch(query) {


### PR DESCRIPTION
**Description**
Fix environment tabs in alert history.

**Changes**
- Get alert history from selected environment
- Show correct count of environment history

