### PR TITLE
feat: add table for viewing which alerts will trigger notification in…

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -250,6 +250,7 @@ export const en = {
   NewNotificationChannel: 'Add New Notification Channel',
   NotificationChannelsInfo: 'Channels/Authentication for SMS/Mail providers',
   EditNotificationChannel: 'Edit Notification Channel',
+  ViewAlerts: 'View Alerts',
   NotificationRuleHistoryId: 'Index of Notification Rule History',
   NotificationRuleHistoryUser: 'User that updated/created the Notification Rule',
   NotificationRuleHistory: 'Notification Rule History For',

--- a/src/services/api/notificationRule.service.ts
+++ b/src/services/api/notificationRule.service.ts
@@ -4,6 +4,12 @@ export default {
   createNotificationRule(data: object) {
     return api.post('/notificationrules', data)
   },
+  getNotificationAlerts(data: object, params: object) {
+    let config = {
+      params: params
+    }
+    return api.post('/notificationrule/alerts', data, config)
+  },
   getNotificationRule(id: string) {
     return api.get(`/notificationrules/${id}`)
   },

--- a/src/store/modules/notificationRule.store.ts
+++ b/src/store/modules/notificationRule.store.ts
@@ -4,6 +4,7 @@ const namespaced = true
 
 const state = {
   isLoading: false,
+  isLoadingAlerts: false,
 
   notification_rules: [],
   selected: [],
@@ -12,6 +13,13 @@ const state = {
   notificationRule: null,
 
   query: {},
+  alerts: [],
+
+  alertsPagination: {
+    page: 1,
+    rowsPerPage: 15,
+    rowsPerPageItems: [10, 15, 30, 50, 100, 200]
+  },
 
   historyPagination: {
     page: 1,
@@ -32,8 +40,17 @@ const mutations = {
   SET_LOADING(state) {
     state.isLoading = true
   },
+  SET_ALERT_LOADING(state) {
+    state.isLoadingAlerts = true
+  },
   SET_SEARCH_QUERY(state, query): any {
     state.query = query
+  },
+  SET_ALERTS(state, [total, alerts, pageSize]) {
+    state.isLoadingAlerts = false
+    state.alertsPagination.totalItems = total
+    state.alertsPagination.rowsPerPage = pageSize
+    state.alerts = alerts
   },
   SET_NOTIFICATION_RULES(state, [notificationRules, total, pageSize]) {
     state.isLoading = false
@@ -60,10 +77,26 @@ const mutations = {
   },
   SET_HISTORY_PAGINATION(state, pagination) {
     state.historyPagination = Object.assign({}, state.historyPagination, pagination)
+  },
+  SET_ALERTS_PAGINATION(state, pagination) {
+    state.alertsPagination = Object.assign({}, state.alertsPagination, pagination)
   }
 }
 
 const actions = {
+  getAlerts({commit, state}, notification_rule) {
+    commit('SET_ALERT_LOADING')
+
+    let params = new URLSearchParams()
+    params.append('page', state.alertsPagination.page)
+    params.append('page-size', state.alertsPagination.rowsPerPage)
+    NotificationRuleApi.getNotificationAlerts(notification_rule, params).then(({alerts, total, pageSize}) =>
+      commit('SET_ALERTS', [total, alerts, pageSize])
+    )
+  },
+  resetAlerts({commit, state}) {
+    commit('SET_ALERTS', [0, [], state.alertsPagination.rowsPerPag])
+  },
   getNotificationRules({commit, state}) {
     commit('SET_LOADING')
     let params = new URLSearchParams(state.query)
@@ -120,6 +153,9 @@ const actions = {
   setHistoryPagination({commit}, pagination) {
     commit('SET_HISTORY_PAGINATION', pagination)
   },
+  setAlertsPagination({commit}, pagination) {
+    commit('SET_ALERTS_PAGINATION', pagination)
+  },
   updateQuery({commit}, query) {
     commit('SET_SEARCH_QUERY', query)
   }
@@ -131,7 +167,8 @@ const getters = {
   },
   historyPagination: state => {
     return state.historyPagination
-  }
+  },
+  alertsPagination: state => state.alertsPagination
 }
 
 export default {


### PR DESCRIPTION
**Description**
Add a table for viewing alerts that can trigger a notification rule

**Changes**
- add 
- add a button on the notification rule edit dialog that opens the table of alerts

**Screenshots**
<img width="546" height="1187" alt="image" src="https://github.com/user-attachments/assets/b762d842-e04f-4530-be8d-6ea4237af7f3" />
<img width="2304" height="244" alt="image" src="https://github.com/user-attachments/assets/d894d85c-2321-4a90-9c1d-070a135d00d5" />
<img width="2307" height="1179" alt="image" src="https://github.com/user-attachments/assets/de6b783a-f7f9-49e6-beff-6f22baebf9b2" />

