### PR TITLE
Fix: show all group IDs in notification rules

### DIFF
--- a/src/components/NotificationGroupList.vue
+++ b/src/components/NotificationGroupList.vue
@@ -348,8 +348,14 @@ export default {
       this.dialog = true
     },
     deleteItem(item) {
-      confirm(i18n.t('ConfirmDelete')) &&
-        this.$store.dispatch('notificationGroups/deleteNotificationGroup', item.id)
+      this.$store.dispatch('notificationRules/getNoificationRulesGroup', item.id).then(
+        (value) => {
+          const rules = value.notificationRules.map(({id, name}) => name ?? id)
+          confirm(`${i18n.t('ConfirmDelete')}\nNotification Rules affected:\n - ${rules.join('\n  - ')}`) &&
+            this.$store.dispatch('notificationGroups/deleteNotificationGroup', item.id)
+        }
+      )
+      
     },    
     close() {
       let change = !this.compareDict(this.editedItem, this.editedItemStart)

--- a/src/components/NotificationRuleList.vue
+++ b/src/components/NotificationRuleList.vue
@@ -457,7 +457,7 @@
                         </v-flex>
 
                         <v-flex xs12>
-                          <v-select
+                          <v-combobox
                             v-model="editedItem.groupIds"
                             :items="groups"
                             item-text="name"
@@ -1490,6 +1490,7 @@ export default {
             { ...b },
             {
               period: period,
+              groupIds: b.groupIds.map((b) => this.groups.filter((a) => a.id === b)[0] ?? b),
               timeObj: {
                 time: b.delayTime,
                 interval: 'second'
@@ -1534,7 +1535,7 @@ export default {
       return this.$store.state.users.users
     },
     groups() {
-      return this.$store.state.notificationGroups.notificationGroups
+      return this.$store.state.notificationGroups.notificationGroups.map(({name, id}) => ({name, id}) )
     },
     computedHeaders() {
       return this.headers.filter(h =>
@@ -1857,7 +1858,7 @@ export default {
             delayTime: this.editedItem.timeObj.time ? `${this.editedItem.timeObj.time} ${this.editedItem.timeObj.interval}` : null,
             receivers: this.editedItem.receivers,
             userIds: this.editedItem.userIds,
-            groupIds: this.editedItem.groupIds,
+            groupIds: this.editedItem.groupIds.map((a) => a.id ?? a),
             useOnCall: this.editedItem.useOnCall,
             service: this.editedItem.service,
             resource: this.editedItem.resource,
@@ -1883,6 +1884,7 @@ export default {
           Object.assign(this.editedItem, {
             id: null,
             startTime: sTimeStr,
+            groupIds: this.editedItem.groupIds.map((a) => a.id ?? a),
             endTime: eTimeStr,
             delayTime: this.editedItem.timeObj.time ? `${this.editedItem.timeObj.time} ${this.editedItem.timeObj.interval}` : null,
             text: this.editedItem.text.replace(/\{([\w\[\]\. ]*)\}/g, '%($1)s'),

--- a/src/components/NotificationRuleList.vue
+++ b/src/components/NotificationRuleList.vue
@@ -1038,12 +1038,25 @@
           <td>{{ props.item.channelId }}</td>
           <td>
             <v-chip
-              v-for="number in [...props.item.receivers, ...users.filter(b => props.item.userIds.includes(b.id)).map(b => b.name), ...groups.filter(b => props.item.groupIds.includes(b.id)).map(b => b.name)]"
+              v-for="number in [
+                ...props.item.receivers,
+                ...users.filter(b => props.item.userIds.includes(b.id)).map(b => b.name),
+                ...props.item.groupIds.map((a) => a.name).filter((a) => a !== undefined)
+              ]"
               :key="number"
               outline
               small
             >
               {{ number }}
+            </v-chip>
+            <v-chip
+              v-for="receiver in props.item.groupIds.filter((a) => groups.filter((b) => a.id === b.id).length === 0)"
+              :key="receiver"
+              outline
+              small
+              color="red"
+            >
+              {{ receiver }}
             </v-chip>
           </td>
           <td>{{ props.item.useOnCall }}</td>

--- a/src/services/api/notificationRule.service.ts
+++ b/src/services/api/notificationRule.service.ts
@@ -10,6 +10,9 @@ export default {
     }
     return api.post('/notificationrule/alerts', data, config)
   },
+  getNotificationRulesByNGroup(groupId: string){
+    return api.get(`/notificationrules/group/${groupId}`)
+  },
   getNotificationRule(id: string) {
     return api.get(`/notificationrules/${id}`)
   },

--- a/src/services/api/notificationRule.service.ts
+++ b/src/services/api/notificationRule.service.ts
@@ -10,7 +10,7 @@ export default {
     }
     return api.post('/notificationrule/alerts', data, config)
   },
-  getNotificationRulesByNGroup(groupId: string){
+  getNotificationRulesByNGroup(groupId: string) {
     return api.get(`/notificationrules/group/${groupId}`)
   },
   getNotificationRule(id: string) {

--- a/src/store/modules/notificationRule.store.ts
+++ b/src/store/modules/notificationRule.store.ts
@@ -94,6 +94,7 @@ const actions = {
       commit('SET_ALERTS', [total, alerts, pageSize])
     )
   },
+
   resetAlerts({commit, state}) {
     commit('SET_ALERTS', [0, [], state.alertsPagination.rowsPerPag])
   },
@@ -113,6 +114,9 @@ const actions = {
         commit('SET_NOTIFICATION_RULES', [notificationRules, total, pageSize])
       )
       .catch(() => commit('RESET_LOADING'))
+  },
+  getNoificationRulesGroup(_, id) {
+    return NotificationRuleApi.getNotificationRulesByNGroup(id)
   },
   getNotificationRuleHistory({commit, state}, id) {
     let params = new URLSearchParams(state.query)


### PR DESCRIPTION
**Description**
Show notification group IDs for notification rules and show which notification rules will be affected when deleting a notification group

**Changes**
- show "hidden"/non-existing notification group IDs in the add/edit notification rules dialog
- add red chips for all non-existing notification group IDs in the notification rule table
- add a list of affected notification rules in the delete alert for notification groups
