### PR TITLE
fix: set currentTab to user-defined when clicking on a alert detail

### DIFF
--- a/src/components/AlertDetail/Detail.vue
+++ b/src/components/AlertDetail/Detail.vue
@@ -169,7 +169,7 @@ const queryBy = (attribute: string, value: any, shift?: boolean) => {
         ...alertFilter.value,
         [attribute]: [...new Set([...(attribute in alertFilter.value ? alertFilter.value[attribute] : []), value])]
       }
-
+  store.dispatch('filterTabs/setCurrentTab', 'user-defined')
   store.dispatch('alerts/setFilter', filter)
   router.push({path: '/alerts'})
 }


### PR DESCRIPTION
**Description**
Set the currentTab to user-defined when changing the filter by clicking on a field value in the alert detail page. This fixes a problem that the filter did not change when clicking a field value because the filter was overwritten by the currentTab filter