### PR TITLE
fix: change to hashHistory urls to suppport subpaths

### DIFF
--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -5,7 +5,7 @@
  */
 
 // Composables
-import {createRouter, createWebHistory, type Router} from 'vue-router/auto'
+import {createRouter, createWebHashHistory, type Router} from 'vue-router/auto'
 import {routes} from 'vue-router/auto-routes'
 import type {Store} from './store/types'
 import type {App} from 'vue'
@@ -13,7 +13,7 @@ import type {App} from 'vue'
 export default function registerRouter(app: App) {
   const config = app.config.globalProperties.$config
   const router = createRouter({
-    history: createWebHistory(config.base ?? '/'),
+    history: createWebHashHistory(config.base ?? '/'),
     routes
   })
 


### PR DESCRIPTION
**Description**
Fix the problem with reloading pages with multiple "/" after using a relative base in the Vite config. Build did not generate the correct files to support paths with multiple "/" characters in nginx, so pages like "/alert/[id]" could not be manually accessed by typing the URL or by refreshing the page after navigating to it. Switching to hashHistory for routing fixes this problem by using hashRoutes, which are correctly handled by nginx. This adds a "/#/" to the front of all paths, changing the URL "http://localhost:3000/alerts" to "http://localhost:3000/#/alerts". When using a subpath like "alerta", it becomes "http://localhost:3000/alerta/#/alerts".