### PR TITLE
feat: add unit options for timeout actions

### DIFF
--- a/src/components/dialogs/TimeoutAction.vue
+++ b/src/components/dialogs/TimeoutAction.vue
@@ -20,14 +20,17 @@
         </v-card-title>
         <v-card-text style="overflow-x: hidden">
           <v-row>
-            <v-col cols="12">
+            <v-col cols="7">
               <g-text-field
                 v-model="timeout"
                 show-header
                 :label="t('Timeout')"
                 type="number"
-                :rules="[(val: number) => val >= 0]"
+                :rules="[(val: number) => (val >= 0 ? true : t('TimeoutNegative'))]"
               />
+            </v-col>
+            <v-col cols="5">
+              <g-select v-model="timeoutUnit" :items="Object.keys(timeoutUnits)" show-header :label="t('Unit')" />
             </v-col>
             <v-col cols="12">
               <g-text-field
@@ -73,6 +76,7 @@ const store: Store = useStore()
 const dialog = ref(false)
 const text = ref('')
 const timeout = ref<null | number>(null)
+const timeoutUnit = ref<keyof typeof timeoutUnits>('minutes')
 const form = ref<VForm | null>(null)
 const maxNoteLength = 200
 
@@ -87,6 +91,13 @@ const actions: {shelve: Description; ack: Description} = {
   ack: {header: 'Ack', icon: 'check', text: 'Description'}
 }
 
+const timeoutUnits = {
+  seconds: 1,
+  minutes: 60,
+  hours: 3600,
+  days: 24 * 3600
+}
+
 const props = defineProps<{action: 'shelve' | 'ack'; id: string; disabled?: boolean; hide?: boolean; dense?: boolean}>()
 
 async function validate() {
@@ -98,7 +109,8 @@ async function validate() {
 }
 
 async function save() {
-  await store.dispatch('alerts/takeAction', [props.id, props.action, text.value, timeout.value || undefined])
+  const timeoutSeconds = (timeout.value ?? 0) * timeoutUnits[timeoutUnit.value]
+  await store.dispatch('alerts/takeAction', [props.id, props.action, text.value, timeoutSeconds || undefined])
   store.dispatch('alerts/getAlerts')
   store.dispatch('alerts/getAlert', props.id)
   close()

--- a/src/components/dialogs/TimeoutAction.vue
+++ b/src/components/dialogs/TimeoutAction.vue
@@ -16,6 +16,11 @@
         <v-card-title>
           <v-col cols="12">
             <span class="header"> {{ t(actions[action].header) }} {{ id }} </span>
+            <br />
+            <information-dialog
+              :info="[actions[action].info, ...info]"
+              :title="actions[action].header + ' ' + t('Action')"
+            />
           </v-col>
         </v-card-title>
         <v-card-text style="overflow-x: hidden">
@@ -84,12 +89,18 @@ type Description = {
   header: string
   icon: string
   text: string
+  info: {title: string; info: string}
 }
 
 const actions: {shelve: Description; ack: Description} = {
-  shelve: {header: 'Shelve', icon: 'schedule', text: 'Reason'},
-  ack: {header: 'Ack', icon: 'check', text: 'Description'}
+  shelve: {header: 'Shelve', icon: 'schedule', text: 'Reason', info: {title: t('Shelve'), info: t('ShelveInfo')}},
+  ack: {header: 'Ack', icon: 'check', text: 'Description', info: {title: t('Ack'), info: t('AckInfo')}}
 }
+
+const info = [
+  {title: t('Timeout'), info: t('TimeoutInfo')},
+  {title: t('Reason'), info: t('ReasonInfo')}
+]
 
 const timeoutUnits = {
   seconds: 1,

--- a/src/components/dialogs/TimeoutActions.vue
+++ b/src/components/dialogs/TimeoutActions.vue
@@ -9,6 +9,10 @@
         <v-card-title>
           <v-col cols="12">
             <span class="header"> {{ t(actions[action].header) }} ({{ alerts.length }}) </span>
+            <information-dialog
+              :info="[actions[action].info, ...info]"
+              :title="actions[action].header + ' ' + t('Action')"
+            />
           </v-col>
         </v-card-title>
         <v-card-text style="overflow-x: hidden">
@@ -77,12 +81,18 @@ type Description = {
   header: string
   icon: string
   text: string
+  info: {title: string; info: string}
 }
 
 const actions: {shelve: Description; ack: Description} = {
-  shelve: {header: 'Shelve', icon: 'schedule', text: 'Reason'},
-  ack: {header: 'Ack', icon: 'check', text: 'Description'}
+  shelve: {header: 'Shelve', icon: 'schedule', text: 'Reason', info: {title: t('Shelve'), info: t('ShelveInfo')}},
+  ack: {header: 'Ack', icon: 'check', text: 'Description', info: {title: t('Ack'), info: t('AckInfo')}}
 }
+
+const info = [
+  {title: t('Timeout'), info: t('TimeoutInfo')},
+  {title: t('Reason'), info: t('ReasonInfo')}
+]
 
 const timeoutUnits = {
   seconds: 1,

--- a/src/components/dialogs/TimeoutActions.vue
+++ b/src/components/dialogs/TimeoutActions.vue
@@ -13,14 +13,17 @@
         </v-card-title>
         <v-card-text style="overflow-x: hidden">
           <v-row>
-            <v-col cols="12">
+            <v-col cols="7">
               <g-text-field
                 v-model="timeout"
                 show-header
                 type="number"
-                :rules="[(val: number) => val >= 0]"
+                :rules="[(val: number) => (val >= 0 ? true : t('TimeoutNegative'))]"
                 :label="t('Timeout')"
               />
+            </v-col>
+            <v-col cols="5">
+              <g-select v-model="timeoutUnit" :items="Object.keys(timeoutUnits)" show-header :label="t('Unit')" />
             </v-col>
             <v-col cols="12">
               <g-text-field
@@ -66,6 +69,7 @@ const store: Store = useStore()
 const dialog = ref(false)
 const text = ref('')
 const timeout = ref<null | number>(null)
+const timeoutUnit = ref<keyof typeof timeoutUnits>('minutes')
 const form = ref<VForm | null>(null)
 const maxNoteLength = 200
 
@@ -78,6 +82,13 @@ type Description = {
 const actions: {shelve: Description; ack: Description} = {
   shelve: {header: 'Shelve', icon: 'schedule', text: 'Reason'},
   ack: {header: 'Ack', icon: 'check', text: 'Description'}
+}
+
+const timeoutUnits = {
+  seconds: 1,
+  minutes: 60,
+  hours: 3600,
+  days: 24 * 3600
 }
 
 const props = defineProps<{action: 'shelve' | 'ack'}>()
@@ -93,7 +104,8 @@ async function validate() {
 }
 
 async function save() {
-  await store.dispatch('alerts/takeActions', [alerts.value, props.action, text.value, timeout.value || undefined])
+  const timeoutSeconds = (timeout.value ?? 0) * timeoutUnits[timeoutUnit.value]
+  await store.dispatch('alerts/takeActions', [alerts.value, props.action, text.value, timeoutSeconds || undefined])
   store.dispatch('alerts/getAlerts')
   close()
 }


### PR DESCRIPTION
**Description**
Add a dropdown to set the action timeout unit to seconds, minutes, hours, or days. Add information dialogs to explain how to use the action timeout dialog