### PR TITLE
feat: add option for max alerts with actions to improve performance

### DIFF
--- a/src/components/Settings/AlertSummary.vue
+++ b/src/components/Settings/AlertSummary.vue
@@ -16,6 +16,9 @@
     <v-col cols="12">
       <g-select v-model="refreshInterval" show-header :items="refreshOptions" :label="t('RefreshInterval')" />
     </v-col>
+    <v-col cols="12">
+      <g-select v-model="maxActionItems" show-header :items="actionOptions" :label="t('MaxActionItems')" />
+    </v-col>
   </v-row>
 </template>
 
@@ -47,5 +50,11 @@ const noteIcon = computed({
 const searchBar = computed({
   get: () => store.getters.getPreference('showSearchBar'),
   set: val => store.dispatch('setUserPrefs', {showSearchBar: val})
+})
+
+const actionOptions = computed(() => store.state.alerts.pagination.itemsPerPageOptions)
+const maxActionItems = computed({
+  get: () => store.getters.getPreference('maxActionItems'),
+  set: val => store.dispatch('setUserPrefs', {maxActionItems: val})
 })
 </script>

--- a/src/components/lists/AlertList.vue
+++ b/src/components/lists/AlertList.vue
@@ -40,21 +40,21 @@
       {{ filters.hhmmss(timeoutLeft(item)) }}
     </template>
     <template #[`item.severity`]="{item}">
-      <v-chip :class="[item.severity]" class="chip" label variant="flat" size="small">
+      <div class="chip" :class="[item.severity]">
         {{ item.severity }}
-      </v-chip>
+      </div>
     </template>
     <template #[`item.status`]="{item}">
-      <v-chip class="chip" label variant="flat" size="small">
+      <div class="chip">
         {{ item.status }}
-      </v-chip>
+      </div>
       <v-tooltip v-if="lastNote(item)" location="bottom" :text="lastNote(item)">
         <template #activator="{props}">
           <v-icon v-bind="props"> sticky_note_2 </v-icon>
         </template>
       </v-tooltip>
     </template>
-    <template #[`item.actions`]="{item}">
+    <template #[`item.actions`]="{item}" v-if="itemsPerPage <= maxItemsWithActions">
       <div class="action-buttons">
         <v-btn
           v-if="isAcked(item.status) || isClosed(item.status)"
@@ -141,7 +141,7 @@
 </template>
 
 <script lang="ts" setup>
-import {computed, ref} from 'vue'
+import {computed, ref, watch} from 'vue'
 import {useStore} from 'vuex'
 import {useRoute, useRouter} from 'vue-router'
 import debounce from 'lodash/debounce'
@@ -160,7 +160,15 @@ const {t} = useI18n()
 
 const confirm = ref<InstanceType<typeof Confirm> | null>(null)
 
-const headersMap = computed(() => ({
+const headersMap = computed<{
+  [key: string]: {
+    title: string
+    key: string
+    headerProps?: {class: string}
+    sortable?: boolean
+    align?: 'end'
+  }
+}>(() => ({
   id: {title: t('AlertId'), key: 'id'},
   resource: {title: t('Resource'), key: 'resource'},
   event: {title: t('Event'), key: 'event'},
@@ -170,7 +178,7 @@ const headersMap = computed(() => ({
   status: {title: t('Status'), key: 'status'},
   service: {title: t('Service'), key: 'service'},
   group: {title: t('Group'), key: 'group'},
-  value: {title: t('Value'), value: 'value'},
+  value: {title: t('Value'), key: 'value'},
   tags: {title: t('Tags'), key: 'tags'},
   attributes: {title: t('Attribute'), key: 'attributes'},
   origin: {title: t('Origin'), key: 'origin'},
@@ -201,6 +209,14 @@ const pagination = computed({
   }
 })
 
+const maxItemsWithActions = computed(() => store.getters.getPreference('maxActionItems'))
+const itemsPerPage = computed(() => store.state.alerts.pagination.itemsPerPage)
+
+watch(itemsPerPage, value => {
+  if (value <= maxItemsWithActions.value && items.value.length > maxItemsWithActions.value)
+    store.commit('alerts/SET_ALERTS', [[], 0, value])
+})
+
 const lastNote = (item: Alert) => {
   const note = item.history.filter(h => ['note', 'dismiss'].includes(h.type)).pop()
   return note?.type == 'note' ? note.text : ''
@@ -215,7 +231,12 @@ const customHeaders = computed(() => {
         sortable: true
       }
   )
-  return [...configHeaders, headersMap.value.actions]
+  return [
+    ...configHeaders,
+    itemsPerPage.value > maxItemsWithActions.value
+      ? {...headersMap.value.actions, headerProps: {class: 'text-disabled'}}
+      : headersMap.value.actions
+  ]
 })
 
 const selected = computed({

--- a/src/plugins/store/modules/preferences.store.ts
+++ b/src/plugins/store/modules/preferences.store.ts
@@ -36,7 +36,8 @@ const getDefaults = (): State => {
     blackoutPeriod: null,
     queries: [],
     navBarCollapsed: false,
-    showSearchBar: false
+    showSearchBar: false,
+    maxActionItems: 50
   }
 }
 

--- a/src/plugins/store/types/preferences-types.ts
+++ b/src/plugins/store/types/preferences-types.ts
@@ -40,6 +40,7 @@ export interface State {
   queries: Query[]
   navBarCollapsed: boolean
   showSearchBar: boolean
+  maxActionItems: number
 }
 
 export type Mutations<S = State> = {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -125,6 +125,9 @@ td {
   font-size: 13px !important;
   border-radius: 20px;
   border: 1px solid;
+  text-align: center;
+  width: fit-content;
+  padding: 3px 10px;
 }
 
 .chip.critical,


### PR DESCRIPTION
**Description**
Improve alert table performance by hiding/removing buttons(actions) from the table when showing many alerts/rows.

**Changes**
- add new user setting for max action items
- remove buttons(actions) when rows exceed the user setting max action items