### PR TITLE
feat: hide user-defined filter tab when current filter is not user-defined

### DIFF
--- a/src/components/dialogs/add/FilterTabAdd.vue
+++ b/src/components/dialogs/add/FilterTabAdd.vue
@@ -71,7 +71,7 @@ const props = defineProps<{
 
 const rules = {
   required: (v: string) => !!v || t('Required'),
-  uniqueName: (v: string) => !props.names.includes(v) || v + t('AlreadyExists')
+  uniqueName: (v: string) => !['user-defined', ...props.names].includes(v) || v + t('AlreadyExists')
 }
 const dialog = ref(false)
 

--- a/src/components/dialogs/add/FilterTabAdd.vue
+++ b/src/components/dialogs/add/FilterTabAdd.vue
@@ -71,7 +71,7 @@ const props = defineProps<{
 
 const rules = {
   required: (v: string) => !!v || t('Required'),
-  uniqueName: (v: string) => !['user-defined', ...props.names].includes(v) || v + t('AlreadyExists')
+  uniqueName: (v: string) => ![t('UserDefined'), ...props.names].includes(v) || v + t('AlreadyExists')
 }
 const dialog = ref(false)
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -88,6 +88,7 @@ export const en = {
 
   // Filter
   RegexHint: 'Add ~ the start of the any of the texts to change to partial search',
+  UserDefined: 'User Filter',
 
   // Alert actions
   TextIsRequired: 'Text is required',

--- a/src/pages/Alerts.vue
+++ b/src/pages/Alerts.vue
@@ -106,7 +106,7 @@
         class="big-font bold no-cap-btn"
         value="user-defined"
       >
-        user-defined ({{ pagination.totalItems }})
+        {{ t('UserDefined') }} ({{ pagination.totalItems }})
       </v-tab>
     </v-tabs>
     <v-row class="mt-0">

--- a/src/pages/Alerts.vue
+++ b/src/pages/Alerts.vue
@@ -101,10 +101,10 @@
         {{ tab.name }}&nbsp;({{ getTabCount(tab.name) }})
       </v-tab>
       <v-tab
+        v-if="currentTab == 'user-defined'"
         style="padding: 0px; margin-right: 26px"
         class="big-font bold no-cap-btn"
         value="user-defined"
-        @click="setFilterTab(filter)"
       >
         user-defined ({{ pagination.totalItems }})
       </v-tab>

--- a/src/pages/History.vue
+++ b/src/pages/History.vue
@@ -44,10 +44,10 @@
       {{ tab.name }}&nbsp;({{ getTabCount(tab.name) }})
     </v-tab>
     <v-tab
+      v-if="currentTab == 'user-defined'"
       style="padding: 0px; margin-right: 26px"
       class="big-font bold no-cap-btn"
       value="user-defined"
-      @click="setFilterTab(filter)"
     >
       user-defined ({{ pagination.totalItems }})
     </v-tab>

--- a/src/pages/History.vue
+++ b/src/pages/History.vue
@@ -49,7 +49,7 @@
       class="big-font bold no-cap-btn"
       value="user-defined"
     >
-      user-defined ({{ pagination.totalItems }})
+      {{ t('UserDefined') }} ({{ pagination.totalItems }})
     </v-tab>
   </v-tabs>
   <v-row class="mt-0">


### PR DESCRIPTION
**Description**
Rename the user-defined filter tab to User Filter and hide the tab when the current filter is not user-defined